### PR TITLE
foldRight not tail-recursive

### DIFF
--- a/sofp-src/sofp-induction.tex
+++ b/sofp-src/sofp-induction.tex
@@ -1862,7 +1862,7 @@ sequences.
 
 The Scala library contains several other methods similar to \lstinline!foldLeft!,
 such as \lstinline!foldRight! and \lstinline!reduce!. (However,
-\lstinline!foldRight! is not tail-recursive!)
+\lstinline!foldRight! is not tail-recursive! - has this been double-checked?)
 
 \subsection{Solved examples: using \texttt{foldLeft}\index{solved examples}}
 


### PR DESCRIPTION
Hello @winitzki  I am loving your book - e.g. very comprehensive and thorough introduction to folding - I found the material so compelling that I couldn't resist putting it at the centre of part 2 of my slide deck on folding: https://www.slideshare.net/pjschwarz/folding-unfolded-polyglot-fp-for-fun-and-profit-haskell-and-scala-part-2 

But when I got to this point about the foldRight function in the Scala standard library not being tail recursive, I went to verify it and as far as I can tell it doesn't seem to be the case. See slides 33 and 34 of the deck: https://www.slideshare.net/pjschwarz/folding-unfolded-polyglot-fp-for-fun-and-profit-haskell-and-scala-part-2#33

Am I missing something? 

Thanks.

P.S. 
https://github.com/scala/scala/blob/v2.13.3/src/library/scala/collection/immutable/List.scala#L348
https://github.com/scala/scala/blob/2.13.x/src/library/scala/collection/IterableOnce.scala#L655