### PR TITLE
Stream deprecation

### DIFF
--- a/sofp-src/sofp-induction.tex
+++ b/sofp-src/sofp-induction.tex
@@ -2404,7 +2404,7 @@ converted to a list or another type of sequence. In this way, we can
 generate a sequence of initially unknown length according to any given
 requirements.
 
-The Scala library has a general stream-producing function \lstinline!Stream.iterate!.
+The Scala library has a general stream-producing function \lstinline!LazyList.iterate!.
 This function has two arguments, the initial value and a function
 that computes the next value from the previous one:
 


### PR DESCRIPTION
Hell Sergei,

I am continuing to find your book very nice/useful and I again ended up referencing sections of it heavily:
https://www.slideshare.net/pjschwarz/the-functional-programming-triad-of-fold-scan-and-iterate
https://www.slideshare.net/pjschwarz/folding-unfolded-polyglot-fp-for-fun-and-profit-haskell-and-scala-part-4

This PR is just to point out (if pointing out is needed - you may well know this already), that Stream is now deprecated in favour of LazyList: "Deprecated (Since version 2.13.0) Use LazyList (which is fully lazy) instead of Stream (which has a lazy tail only)" https://www.scala-lang.org/api/current/scala/collection/immutable/Stream.html

LazyList also has an iterate function:
https://www.scala-lang.org/api/current/scala/collection/immutable/LazyList$.html#iterate[A](start:=%3EA)(f:A=%3EA):scala.collection.immutable.LazyList[A]

(https://www.scala-lang.org/api/current/scala/collection/immutable/Stream.html says "Deprecated
(Since version 2.13.0) Use LazyList (which is fully lazy) instead of Stream (which has a lazy tail only)"

I don't know if you want to update the book to use LazyList instead of Stream (btw, I think I find the name LazyList a bit odd - a bit distracting - I like the plainness of Stream). It looks like this old post says Stream will be removed in 2.14: https://www.scala-lang.org/blog/2018/06/13/scala-213-collections.html

Philip