### PR TITLE
Remove obsolete step from CI build

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -24,12 +24,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Build PDF using the basic commands
-        id: simple-pdf
-        uses: docker://feastingmonk/sofp-builder:latest
-        with:
-          args: ". sofp-src/make_sofp_pdf_simple.sh"
-
       - name: Build PDF using make_sofp_pdf.sh
         id: full-pdf
         uses: docker://feastingmonk/sofp-builder:latest


### PR DESCRIPTION
The `make_sofp_pdf_simple.sh` script had been deleted, but the workflow still referenced. This caused CI runs after the commit that removed the script to fail. Let's update the workflow.