### PR TITLE
Point to new location for script that was moved

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -30,7 +30,7 @@ jobs:
         id: full-pdf
         uses: docker://winitzki/sofp-docker-build:latest
         with:
-          args: "LYXDIR=/root/.lyx bash sofp-src/make_all.sh"
+          args: "LYXDIR=/root/.lyx bash sofp-src/scripts/make_all.sh"
         
       - name: Upload built PDF
         id: upload-pdf


### PR DESCRIPTION
The build is failing with output
```
Running LYXDIR=/root/.lyx bash sofp-src/make_all.sh in /github/workspace
bash: sofp-src/make_all.sh: No such file or directory
```

`make_all.sh` was previously moved to the `scripts` subdirectory.